### PR TITLE
chore: upgrade go dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cpuguy83/go-md2man v1.0.10
 	github.com/genkiroid/cert v0.0.0-20191007122723-897560fbbe50
-	github.com/jenkins-x/jx-api/v4 v4.0.20
-	github.com/jenkins-x/jx-helpers/v3 v3.0.61
+	github.com/jenkins-x/jx-api/v4 v4.0.21
+	github.com/jenkins-x/jx-helpers/v3 v3.0.62
 	github.com/jenkins-x/jx-logging/v3 v3.0.3
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -313,11 +313,14 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
+github.com/jenkins-x/go-scm v1.5.209 h1:Me6lEJ7TmAYf26qwLRUJVP6Mt+92AAwmJWQ5ztHzcVE=
 github.com/jenkins-x/go-scm v1.5.209/go.mod h1:pTp8HHrCEVGs24H/8Cy+X/CDXFlKv9VC6zmrXBYNkfE=
 github.com/jenkins-x/jx-api/v4 v4.0.20 h1:zusFMviPwFYeHM/EyB29aeGqRA9WmdJ3bAPQBXM8tZE=
 github.com/jenkins-x/jx-api/v4 v4.0.20/go.mod h1:e98SpJGhOodGShusrGhMqSzRsyZbVsPjWGpEQ2hC0Mk=
-github.com/jenkins-x/jx-helpers/v3 v3.0.61 h1:WQpQ8tlcn6Dq9SCVjHrzZbfJG/OdWsHLXE4A2l71Hk4=
-github.com/jenkins-x/jx-helpers/v3 v3.0.61/go.mod h1:Q4xn9qdOfYrFEdsCK2dgtzeGGFS7uwW5M55utf4FtYA=
+github.com/jenkins-x/jx-api/v4 v4.0.21 h1:OGmGNh8X/VZXg7ptFd4sj2tbXvowUz9XvxnMVkpR9Hk=
+github.com/jenkins-x/jx-api/v4 v4.0.21/go.mod h1:+FL32x44hzToYo2RpfynjYOJORkmZgPKjtdxsAzReFg=
+github.com/jenkins-x/jx-helpers/v3 v3.0.62 h1:HqjDK3QxspVjbx7vLDB/tuC8ajd6mRo39ciSBzroNZA=
+github.com/jenkins-x/jx-helpers/v3 v3.0.62/go.mod h1:rQpQKQ4grt0nbt5EZbYEQ/Anr6g3aOA8b5FPB8tL5gY=
 github.com/jenkins-x/jx-kube-client/v3 v3.0.1 h1:zMnxoLRXJJ85PAd9OVPlgXT5T8xHgbmxSMhpYPTF5mw=
 github.com/jenkins-x/jx-kube-client/v3 v3.0.1/go.mod h1:0CYp1ACEgSmOxul1bx5qbZgQGEcyAeGdBOBa+u62zZY=
 github.com/jenkins-x/jx-logging/v3 v3.0.2 h1:9IEeySM86yECc520Spaq38xO8JIpb6QDl1jFBEQHAwg=


### PR DESCRIPTION
from: https://github.com/jenkins-x/jx3-versions
