### PR TITLE
fix: add a verify pods command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,12 @@ require (
 	github.com/cpuguy83/go-md2man v1.0.10
 	github.com/genkiroid/cert v0.0.0-20191007122723-897560fbbe50
 	github.com/jenkins-x/jx-api/v4 v4.0.24
-	github.com/jenkins-x/jx-helpers/v3 v3.0.75
+	github.com/jenkins-x/jx-helpers/v3 v3.0.77
 	github.com/jenkins-x/jx-logging/v3 v3.0.3
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	github.com/stretchr/testify v1.6.1
 	k8s.io/api v0.20.2
 	k8s.io/apimachinery v0.20.2
 	k8s.io/client-go v11.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -321,7 +321,6 @@ github.com/googleapis/gnostic v0.4.1 h1:DLJCy1n/vrD4HPjOvYcT8aYQXpPIzoRZONaYwyyc
 github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3ir6b65WBswg=
 github.com/googleapis/gnostic v0.5.4 h1:ynbQIWjLw7iv6HAFdixb30U7Uvcmx+f4KlLJpmhkTK0=
 github.com/googleapis/gnostic v0.5.4/go.mod h1:TRWw1s4gxBGjSe301Dai3c7wXJAZy57+/6tawkOvqHQ=
-github.com/gophercloud/gophercloud v0.15.0/go.mod h1:VX0Ibx85B60B5XOrZr6kaNwrmPUzcmMpwxvQ1WQIIWM=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
@@ -377,8 +376,8 @@ github.com/jenkins-x/go-scm v1.5.216 h1:aQK0rthmvoEh6HqNmb4nPdr0Dj474Q7T6/lFgOrj
 github.com/jenkins-x/go-scm v1.5.216/go.mod h1:Iuk0V0mt0QGIt50TZyChHqRIiXTnp1ink9RyNoe7o7c=
 github.com/jenkins-x/jx-api/v4 v4.0.24 h1:REuDkac0UCB/rAlbLt/Jd8LpaGGnGctr5dee8mKVHng=
 github.com/jenkins-x/jx-api/v4 v4.0.24/go.mod h1:IC88X+24Nmexuj7lRNRgzfrchzlo0qysfwkICpqDmMQ=
-github.com/jenkins-x/jx-helpers/v3 v3.0.75 h1:A05rjCrkIjFd7LgKtmI94GKknF7sxYG9xUvTaxjZWj4=
-github.com/jenkins-x/jx-helpers/v3 v3.0.75/go.mod h1:7vMqq0JezRKQ8ZD0Yh1eO3D3dMKuH26S4JEAs5rBi88=
+github.com/jenkins-x/jx-helpers/v3 v3.0.77 h1:lpjYQ39hYKrTsEhwjEdtMakD6U3XeI52GjYbNAu9bwo=
+github.com/jenkins-x/jx-helpers/v3 v3.0.77/go.mod h1:VADIX457jA9xwtfNSFXctQReXEfsM7WL7JZZ1vHKjHY=
 github.com/jenkins-x/jx-kube-client/v3 v3.0.2 h1:sJs6FaIwycDYwE4UsA7j9tpdXOxXEta9KNUJp6s45VI=
 github.com/jenkins-x/jx-kube-client/v3 v3.0.2/go.mod h1:C/mKnCT5wvolX61eLKJVBNev9sqnkGNpi4skTQ1Gr3Q=
 github.com/jenkins-x/jx-logging/v3 v3.0.3 h1:sVACbwiKuaDFYPfJeVAU10MJI4DA6LcH1RqJKwfNozc=
@@ -626,7 +625,6 @@ golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190617133340-57b3e21c3d56/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20191202143827-86a70503ff7e/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0 h1:hb9wdF1z5waM+dSIICn1l0DkLVDT3hqhhQsDNUmHPRE=
@@ -762,7 +760,6 @@ golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191002063906-3421d5a6bb1c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191128015809-6d18c012aee9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200113162924-86b910548bc1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1032,8 +1029,6 @@ k8s.io/code-generator v0.20.2/go.mod h1:UsqdF+VX4PU2g46NC2JRs4gc+IfrctnwHb76RNbW
 k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20201113003025-83324d819ded/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
 k8s.io/helm v2.16.10+incompatible/go.mod h1:LZzlS4LQBHfciFOurYBFkCMTaZ0D1l+p0teMg7TSULI=
-k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
-k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/klog/v2 v2.2.0 h1:XRvcwJozkgZ1UQJmfMGpvRthQHOvihEhYtDfAaxMz/A=
 k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=

--- a/pkg/cmd/pods/pods.go
+++ b/pkg/cmd/pods/pods.go
@@ -1,0 +1,194 @@
+package pods
+
+import (
+	"context"
+	"fmt"
+	"github.com/jenkins-x/jx-helpers/v3/pkg/kube/pods"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+	"os"
+	"sync/atomic"
+	"time"
+
+	"github.com/jenkins-x/jx-helpers/v3/pkg/cobras/helper"
+	"github.com/jenkins-x/jx-helpers/v3/pkg/cobras/templates"
+	"github.com/jenkins-x/jx-helpers/v3/pkg/kube"
+	"github.com/jenkins-x/jx-logging/v3/pkg/log"
+	"github.com/jenkins-x/jx-verify/pkg/rootcmd"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/kubernetes"
+)
+
+// ErrImagePullMessage the message on an event if it can't pull a pod
+const ErrImagePullMessage = "Error: ErrImagePull"
+
+//  ErrImagePullBackOffMessage if we are backing off
+const ErrImagePullBackOffMessage = "Error: ImagePullBackOff"
+
+var (
+	cmdLong = templates.LongDesc(`
+		Verifies that all pods start OK in the current namespace; killing any Pods which have ErrImagePul
+`)
+
+	cmdExample = templates.Examples(`
+		# populate the pods don't have missing images
+		jx verify pods
+
+			`)
+)
+
+type Options struct {
+	KubeClient kubernetes.Interface
+	Namespace  string
+	Selector   string
+	PodCount   int
+	IsReady    atomic.Value
+	readyPods  map[string]bool
+	stop       chan struct{}
+}
+
+func NewCmdVerifyPods() (*cobra.Command, *Options) {
+	o := &Options{}
+
+	cmd := &cobra.Command{
+		Use:     "pods",
+		Short:   "Verifies that all pods start OK in the current namespace; killing any Pods which have ErrImagePull",
+		Long:    cmdLong,
+		Example: fmt.Sprintf(cmdExample, rootcmd.BinaryName),
+		Run: func(cmd *cobra.Command, args []string) {
+			err := o.Run()
+			helper.CheckErr(err)
+		},
+	}
+	cmd.Flags().StringVarP(&o.Namespace, "namespace", "n", "", "The namespace to look for events")
+	cmd.Flags().StringVarP(&o.Selector, "selector", "s", "", "The selector to query for all pods being running")
+	cmd.Flags().IntVarP(&o.PodCount, "count", "c", 1, "The minimum Ready pod count required matching the selector before terminating")
+
+	return cmd, o
+}
+
+func (o *Options) Run() error {
+	var err error
+
+	if o.readyPods == nil {
+		o.readyPods = map[string]bool{}
+	}
+	o.KubeClient, o.Namespace, err = kube.LazyCreateKubeClientAndNamespace(o.KubeClient, o.Namespace)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create kubernetes client")
+	}
+
+	o.stop = make(chan struct{})
+	defer close(o.stop)
+	defer runtime.HandleCrash()
+
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(
+		o.KubeClient,
+		time.Minute*10,
+		informers.WithNamespace(o.Namespace),
+	)
+
+	eventInformer := informerFactory.Core().V1().Events().Informer()
+
+	eventInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			e := obj.(*v1.Event)
+			if e == nil {
+				log.Logger().Warnf("no Event found for %v", obj)
+				return
+			}
+			o.OnEvent(e, o.Namespace)
+			log.Logger().Debugf("added Event %s", e.Name)
+		},
+		UpdateFunc: func(old, obj interface{}) {
+			e := obj.(*v1.Event)
+			if e == nil {
+				log.Logger().Warnf("no Event found for %v", obj)
+				return
+			}
+			o.OnEvent(e, o.Namespace)
+			log.Logger().Debugf("updated Event %s", e.Name)
+		},
+	})
+
+	podInformer := informerFactory.Core().V1().Pods().Informer()
+
+	podInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			p := obj.(*v1.Pod)
+			o.OnPod(p, o.Namespace)
+			log.Logger().Debugf("added Pod %s", p.Name)
+		},
+		UpdateFunc: func(old, new interface{}) {
+			p := new.(*v1.Pod)
+			o.OnPod(p, o.Namespace)
+			log.Logger().Debugf("updated Pod %s", p.Name)
+		},
+	})
+
+	// Starts all the shared informers that have been created by the factory so
+	// far.
+
+	informerFactory.Start(o.stop)
+
+	// wait for the initial synchronization of the local cache
+	if !cache.WaitForCacheSync(o.stop, eventInformer.HasSynced) {
+		runtime.HandleError(fmt.Errorf("timed out waiting for event caches to sync"))
+	}
+	if !cache.WaitForCacheSync(o.stop, podInformer.HasSynced) {
+		runtime.HandleError(fmt.Errorf("timed out waiting for pod caches to sync"))
+	}
+	o.IsReady.Store(true)
+
+	<-o.stop
+
+	// Wait forever
+	select {}
+}
+
+func (o *Options) OnEvent(e *v1.Event, namespace string) {
+	if e.InvolvedObject.Kind != "Pod" {
+		return
+	}
+	if e.Message != ErrImagePullMessage && e.Message != ErrImagePullBackOffMessage {
+		log.Logger().Debugf("ignoring pod message %s", e.Message)
+		return
+	}
+
+	ns := e.InvolvedObject.Namespace
+	if ns == "" {
+		ns = namespace
+	}
+	name := e.InvolvedObject.Name
+	log.Logger().Infof("found pod %s with message %s", name, e.Message)
+
+	ctx := context.TODO()
+	err := o.KubeClient.CoreV1().Pods(ns).Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil {
+		log.Logger().Errorf("failed to delete Pod %s in namespace %s : %s", name, ns, err.Error())
+		return
+	}
+
+	log.Logger().Infof("deleted pod %s in namespace %s", name, ns)
+}
+
+func (o *Options) OnPod(p *v1.Pod, namespace string) {
+	name := p.Name
+	if pods.IsPodReady(p) {
+		o.readyPods[name] = true
+	} else {
+		delete(o.readyPods, name)
+	}
+
+	count := len(o.readyPods)
+	if count < o.PodCount {
+		return
+	}
+
+	log.Logger().Infof("has %d ready pods now", count)
+	os.Exit(0)
+}

--- a/pkg/cmd/pods/pods_test.go
+++ b/pkg/cmd/pods/pods_test.go
@@ -1,0 +1,64 @@
+package pods_test
+
+import (
+	"context"
+	"github.com/jenkins-x/jx-verify/pkg/cmd/pods"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"testing"
+)
+
+func TestPods(t *testing.T) {
+	ns := "jx"
+	podName := "my-pod"
+
+	_, o := pods.NewCmdVerifyPods()
+	kubeClient := fake.NewSimpleClientset(&v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: ns,
+		},
+	})
+	o.KubeClient = kubeClient
+	o.Namespace = ns
+
+	podInterface := kubeClient.CoreV1().Pods(ns)
+
+	ctx := context.TODO()
+
+	RequirePodCount(t, ctx, podInterface, 1)
+
+	o.OnEvent(&v1.Event{
+		InvolvedObject: v1.ObjectReference{
+			Kind: "ConfigMap",
+			Name: "cheese",
+		},
+		Message: "",
+	}, ns)
+
+	RequirePodCount(t, ctx, podInterface, 1)
+
+	o.OnEvent(&v1.Event{
+		InvolvedObject: v1.ObjectReference{
+			Kind:      "Pod",
+			Name:      podName,
+			Namespace: ns,
+		},
+		Message: pods.ErrImagePullMessage,
+	}, ns)
+
+	RequirePodCount(t, ctx, podInterface, 0)
+}
+
+// RequirePodCount requires the given number of pods to exist
+func RequirePodCount(t *testing.T, ctx context.Context, podInterface corev1.PodInterface, expectedLen int) {
+	podList, err := podInterface.List(ctx, metav1.ListOptions{})
+	require.NoError(t, err, "failed to list pods")
+	require.NotNil(t, podList, "no PodList returned")
+
+	require.Len(t, podList.Items, expectedLen, "expected PodList.Items count")
+	//t.Logf("now has %d pods\n", len(podList.Items))
+}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"github.com/jenkins-x/jx-logging/v3/pkg/log"
 	"github.com/jenkins-x/jx-verify/pkg/cmd/ingress"
 	"github.com/jenkins-x/jx-verify/pkg/cmd/install"
+	"github.com/jenkins-x/jx-verify/pkg/cmd/pods"
 	"github.com/jenkins-x/jx-verify/pkg/cmd/tls"
 	"github.com/jenkins-x/jx-verify/pkg/cmd/version"
 	"github.com/jenkins-x/jx-verify/pkg/rootcmd"
@@ -25,6 +26,7 @@ func Main() *cobra.Command {
 	}
 	cmd.AddCommand(cobras.SplitCommand(ingress.NewCmdVerifyIngress()))
 	cmd.AddCommand(cobras.SplitCommand(install.NewCmdVerifyInstall()))
+	cmd.AddCommand(cobras.SplitCommand(pods.NewCmdVerifyPods()))
 	cmd.AddCommand(cobras.SplitCommand(tls.NewCmdVerifyTLS()))
 	cmd.AddCommand(cobras.SplitCommand(version.NewCmdVersion()))
 


### PR DESCRIPTION
so that we can remove any pod thats failing to load the image

as we sometimes see this issue on GCP if an image can't be pulled yet; removing the pod helps get k8s unstuck in BDD tests